### PR TITLE
Cover backend routes in Oracle JET frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+# Node.js
+node_modules/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests specified\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/frontend/src/js/config/serviceConfig.js
+++ b/frontend/src/js/config/serviceConfig.js
@@ -1,0 +1,6 @@
+export default {
+  core: 'http://localhost:8080/api/v1',
+  document: 'http://localhost:8082/api/v1',
+  payment: 'http://localhost:8083/api/v1',
+  notification: 'http://localhost:8084/api/v1'
+};

--- a/frontend/src/js/services/apiService.js
+++ b/frontend/src/js/services/apiService.js
@@ -1,0 +1,281 @@
+import svc from '../config/serviceConfig.js';
+
+const authHeader = (user, pw) => ({
+  'Authorization': 'Basic ' + btoa(`${user}:${pw}`),
+  'Content-Type': 'application/json'
+});
+
+export async function register(data) {
+  const res = await fetch(`${svc.core}/auth/register`, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+export async function login(data) {
+  const res = await fetch(`${svc.core}/auth/login`, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+export async function getCustomers(auth, query = '') {
+  const url = `${svc.core}/customers${query ? `?q=${encodeURIComponent(query)}` : ''}`;
+  const res = await fetch(url, { headers: authHeader(auth.user, auth.pw) });
+  return res.json();
+}
+
+// Customer routes
+export async function createCustomer(auth, data) {
+  const res = await fetch(`${svc.core}/customers`, {
+    method: 'POST',
+    headers: authHeader(auth.user, auth.pw),
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+export async function getCustomer(auth, id) {
+  const res = await fetch(`${svc.core}/customers/${id}`, {
+    headers: authHeader(auth.user, auth.pw)
+  });
+  return res.json();
+}
+
+export async function updateCustomer(auth, id, data) {
+  const res = await fetch(`${svc.core}/customers/${id}`, {
+    method: 'PATCH',
+    headers: authHeader(auth.user, auth.pw),
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+export async function deleteCustomer(auth, id) {
+  const res = await fetch(`${svc.core}/customers/${id}`, {
+    method: 'DELETE',
+    headers: authHeader(auth.user, auth.pw)
+  });
+  return res.ok;
+}
+
+// Product routes
+export async function createProduct(auth, data) {
+  const res = await fetch(`${svc.core}/products`, {
+    method: 'POST',
+    headers: authHeader(auth.user, auth.pw),
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+export async function getProducts(auth, query = '') {
+  const url = `${svc.core}/products${query ? `?${query}` : ''}`;
+  const res = await fetch(url, { headers: authHeader(auth.user, auth.pw) });
+  return res.json();
+}
+
+export async function getProduct(auth, id) {
+  const res = await fetch(`${svc.core}/products/${id}`, {
+    headers: authHeader(auth.user, auth.pw)
+  });
+  return res.json();
+}
+
+export async function updateProduct(auth, id, data) {
+  const res = await fetch(`${svc.core}/products/${id}`, {
+    method: 'PATCH',
+    headers: authHeader(auth.user, auth.pw),
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+export async function deleteProduct(auth, id) {
+  const res = await fetch(`${svc.core}/products/${id}`, {
+    method: 'DELETE',
+    headers: authHeader(auth.user, auth.pw)
+  });
+  return res.ok;
+}
+
+// Quote routes
+export async function createQuote(auth, data) {
+  const res = await fetch(`${svc.core}/quotes`, {
+    method: 'POST',
+    headers: authHeader(auth.user, auth.pw),
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+export async function getQuotes(auth, query = '') {
+  const url = `${svc.core}/quotes${query ? `?${query}` : ''}`;
+  const res = await fetch(url, { headers: authHeader(auth.user, auth.pw) });
+  return res.json();
+}
+
+export async function getQuote(auth, id) {
+  const res = await fetch(`${svc.core}/quotes/${id}`, {
+    headers: authHeader(auth.user, auth.pw)
+  });
+  return res.json();
+}
+
+export async function updateQuote(auth, id, data) {
+  const res = await fetch(`${svc.core}/quotes/${id}`, {
+    method: 'PATCH',
+    headers: authHeader(auth.user, auth.pw),
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+export async function priceQuote(auth, id) {
+  const res = await fetch(`${svc.core}/quotes/${id}/price`, {
+    method: 'POST',
+    headers: authHeader(auth.user, auth.pw)
+  });
+  return res.json();
+}
+
+export async function confirmQuote(auth, id) {
+  const res = await fetch(`${svc.core}/quotes/${id}/confirm`, {
+    method: 'POST',
+    headers: authHeader(auth.user, auth.pw)
+  });
+  return res.json();
+}
+
+// Policy routes
+export async function getPolicies(auth, query = '') {
+  const url = `${svc.core}/policies${query ? `?${query}` : ''}`;
+  const res = await fetch(url, { headers: authHeader(auth.user, auth.pw) });
+  return res.json();
+}
+
+export async function getPolicy(auth, id) {
+  const res = await fetch(`${svc.core}/policies/${id}`, {
+    headers: authHeader(auth.user, auth.pw)
+  });
+  return res.json();
+}
+
+// Claim routes
+export async function createClaim(auth, data) {
+  const res = await fetch(`${svc.core}/claims`, {
+    method: 'POST',
+    headers: authHeader(auth.user, auth.pw),
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+export async function getClaims(auth, query = '') {
+  const url = `${svc.core}/claims${query ? `?${query}` : ''}`;
+  const res = await fetch(url, { headers: authHeader(auth.user, auth.pw) });
+  return res.json();
+}
+
+export async function getClaim(auth, id) {
+  const res = await fetch(`${svc.core}/claims/${id}`, {
+    headers: authHeader(auth.user, auth.pw)
+  });
+  return res.json();
+}
+
+export async function updateClaim(auth, id, data) {
+  const res = await fetch(`${svc.core}/claims/${id}`, {
+    method: 'PATCH',
+    headers: authHeader(auth.user, auth.pw),
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+export async function assessClaim(auth, id, data) {
+  const res = await fetch(`${svc.core}/claims/${id}/assess`, {
+    method: 'POST',
+    headers: authHeader(auth.user, auth.pw),
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+export async function closeClaim(auth, id) {
+  const res = await fetch(`${svc.core}/claims/${id}/close`, {
+    method: 'POST',
+    headers: authHeader(auth.user, auth.pw)
+  });
+  return res.json();
+}
+
+// Document service routes (no auth)
+export async function uploadDocument(meta, file) {
+  const form = new FormData();
+  form.append('meta', new Blob([JSON.stringify(meta)], { type: 'application/json' }));
+  form.append('file', file);
+  const res = await fetch(`${svc.document}/documents`, {
+    method: 'POST',
+    body: form
+  });
+  return res.json();
+}
+
+export async function listDocuments(params) {
+  const q = new URLSearchParams(params).toString();
+  const res = await fetch(`${svc.document}/documents${q ? `?${q}` : ''}`);
+  return res.json();
+}
+
+export async function getDocument(id) {
+  const res = await fetch(`${svc.document}/documents/${id}`);
+  return res.json();
+}
+
+export async function deleteDocument(id) {
+  const res = await fetch(`${svc.document}/documents/${id}`, {
+    method: 'DELETE'
+  });
+  return res.ok;
+}
+
+// Payment service routes (no auth)
+export async function createPayment(data) {
+  const res = await fetch(`${svc.payment}/payments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+export async function getPayments(params) {
+  const q = new URLSearchParams(params).toString();
+  const res = await fetch(`${svc.payment}/payments${q ? `?${q}` : ''}`);
+  return res.json();
+}
+
+export async function getPayment(id) {
+  const res = await fetch(`${svc.payment}/payments/${id}`);
+  return res.json();
+}
+
+// Notification service routes (no auth)
+export async function sendTestEmail(data) {
+  const res = await fetch(`${svc.notification}/emails/test`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  return res.json();
+}
+
+export async function emailHealth() {
+  const res = await fetch(`${svc.notification}/emails/health`);
+  return res.json();
+}

--- a/frontend/src/js/viewModels/login.js
+++ b/frontend/src/js/viewModels/login.js
@@ -1,0 +1,19 @@
+import ko from 'knockout';
+import { login } from '../services/apiService.js';
+
+function LoginViewModel() {
+  this.username = ko.observable('');
+  this.password = ko.observable('');
+  this.messages = ko.observableArray([]);
+
+  this.doLogin = async () => {
+    try {
+      const user = await login({ username: this.username(), password: this.password() });
+      this.messages([{ severity: 'confirmation', summary: 'Logged in', detail: `Welcome ${user.username}` }]);
+    } catch (e) {
+      this.messages([{ severity: 'error', summary: 'Login failed', detail: e.message }]);
+    }
+  };
+}
+
+export default LoginViewModel;

--- a/frontend/src/js/viewModels/workflow.js
+++ b/frontend/src/js/viewModels/workflow.js
@@ -1,0 +1,121 @@
+import ko from 'knockout';
+import {
+  register,
+  login,
+  createCustomer,
+  createProduct,
+  createQuote,
+  priceQuote,
+  confirmQuote,
+  createClaim,
+  assessClaim,
+  closeClaim,
+  createPayment,
+  uploadDocument,
+  sendTestEmail,
+  getPolicies
+} from '../services/apiService.js';
+
+function WorkflowViewModel() {
+  this.log = ko.observable('');
+
+  this.run = async () => {
+    const steps = [];
+    const creds = { user: 'alice', pw: 'secret' };
+    try {
+      steps.push('register user');
+      await register({ username: creds.user, password: creds.pw, role: 'USER' });
+
+      steps.push('login');
+      await login({ username: creds.user, password: creds.pw });
+
+      steps.push('create customer');
+      const customer = await createCustomer(creds, {
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john@example.com',
+        phone: '1234567890',
+        dob: '1990-01-01'
+      });
+
+      steps.push('create product');
+      const product = await createProduct(creds, {
+        name: 'Term Life',
+        code: 'TERM01',
+        description: 'Life cover',
+        baseRatePer1000: 5,
+        minSumAssured: 50000,
+        maxSumAssured: 500000,
+        minTermMonths: 12,
+        maxTermMonths: 240,
+        active: true
+      });
+
+      steps.push('create quote');
+      const quote = await createQuote(creds, {
+        customerId: customer.id,
+        productId: product.id,
+        sumAssured: 100000,
+        termMonths: 120
+      });
+
+      steps.push('price quote');
+      await priceQuote(creds, quote.id);
+
+      steps.push('confirm quote');
+      const policy = await confirmQuote(creds, quote.id);
+
+      steps.push('make payment');
+      await createPayment({
+        targetType: 'POLICY',
+        targetId: policy.id,
+        amount: 1000,
+        method: 'CARD'
+      });
+
+      steps.push('upload document');
+      const blob = new Blob(['demo'], { type: 'text/plain' });
+      await uploadDocument({ ownerId: policy.id, ownerType: 'POLICY', label: 'ID Proof' }, blob);
+
+      steps.push('create claim');
+      const claim = await createClaim(creds, {
+        policyId: policy.id,
+        lossDate: '2024-01-10',
+        description: 'Accident'
+      });
+
+      steps.push('assess claim');
+      await assessClaim(creds, claim.id, {
+        decision: 'APPROVE',
+        approvedAmount: 5000,
+        reason: 'Valid docs'
+      });
+
+      steps.push('close claim');
+      await closeClaim(creds, claim.id);
+
+      steps.push('send notification');
+      await sendTestEmail({
+        eventId: 'evt-1',
+        template: 'welcome',
+        to: ['user@example.com'],
+        cc: [],
+        subject: 'Hello',
+        model: { name: 'User' },
+        metadata: { origin: 'test' },
+        sendAfter: '2024-06-01T10:00:00Z'
+      });
+
+      const policies = await getPolicies(creds, `customer_id=${customer.id}`);
+      steps.push(`workflow complete: ${policies.length} policy(s)`);
+
+      this.log(steps.join('\n'));
+    } catch (e) {
+      steps.push(`error: ${e.message}`);
+      this.log(steps.join('\n'));
+    }
+  };
+}
+
+export default WorkflowViewModel;
+

--- a/frontend/src/js/views/login.html
+++ b/frontend/src/js/views/login.html
@@ -1,0 +1,6 @@
+<oj-form-layout>
+  <oj-input-text id="username" value="{{username}}" label-hint="Username"></oj-input-text>
+  <oj-input-password id="password" value="{{password}}" label-hint="Password"></oj-input-password>
+  <oj-button on-oj-action="[[doLogin]]">Login</oj-button>
+  <oj-messages messages="[[messages]]"></oj-messages>
+</oj-form-layout>

--- a/frontend/src/js/views/workflow.html
+++ b/frontend/src/js/views/workflow.html
@@ -1,0 +1,3 @@
+<oj-button on-oj-action="[[run]]">Run Demo Workflow</oj-button>
+<pre data-bind="text: log"></pre>
+


### PR DESCRIPTION
## Summary
- expand API service to wrap all customer, product, quote, policy, claim, document, payment and notification routes
- add demo workflow view and model to exercise the routes in sequence

## Testing
- `npm test --prefix frontend`
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68baa8b9e6d88327b3874bdd5a37a0b1